### PR TITLE
clean state before transfer

### DIFF
--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -40,7 +40,10 @@ export function share<T extends Store, K extends keyof T['$state']>(
     (state) => {
       if (!externalUpdate) {
         timestamp = Date.now()
-        channel.postMessage({ timestamp, state })
+        channel.postMessage({
+          timestamp,
+          state: JSON.parse(JSON.stringify(state)),
+        });
       }
       externalUpdate = false
     },
@@ -49,7 +52,10 @@ export function share<T extends Store, K extends keyof T['$state']>(
 
   channel.onmessage = (evt) => {
     if (evt === undefined) {
-      channel.postMessage({ timestamp, state: store[key] })
+      channel.postMessage({
+        timestamp,
+        state: JSON.parse(JSON.stringify(store[key])),
+      });
       return
     }
     if (evt.timestamp <= timestamp)


### PR DESCRIPTION
It seems like `broadcast-channel` can't handle all the things vuejs does to a regular object / array to keep track of its state. That's why it appears to be necessary to deep copy the state via a simple JSON stringify & parse

Fixes #7