### PR TITLE
Add a simple "merge" function option to control how local and shared states are synced

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ pinia.use(
     initialize: false,
     // Enforce a type. One of native, idb, localstorage or node. Defaults to native.
     type: 'localstorage',
+    // Optional: Custom serializer for state serialization.
+    serializer: {
+      serialize: JSON.stringify,
+      deserialize: JSON.parse
+    },
+    // Optional: Custom merger function to control how shared state is merged on updates.
+    merger: (key, localState, sharedState, storeId) => {
+      // Custom merge logic based on store and/or key
+      if (storeId === 'special-store') {
+        return Object.assign({}, localState, sharedState)
+      }
+      // Default behavior - use shared state
+      return sharedState
+    },
   }),
 )
 ```
@@ -45,6 +59,19 @@ const useStore = defineStore({
     // Override global config for this store.
     enable: true,
     initialize: true,
+    // Custom serializer for this specific store.
+    serializer: {
+      serialize: JSON.stringify,
+      deserialize: JSON.parse
+    },
+    // Custom merger for this specific store.
+    merger: (key, localState, sharedState) => {
+      // Example: Merge arrays instead of replacing them.
+      if (Array.isArray(localState) && Array.isArray(sharedState)) {
+        return [...new Set([...localState, ...sharedState])]
+      }
+      return sharedState
+    }
   },
 })
 ```

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,9 +3,27 @@ export interface Serializer {
   deserialize: (value: string) => any
 }
 
+export interface Merger {
+  <S>(
+    key: string | number | symbol,
+    localState: S,
+    sharedState: S,
+    storeId?: string,
+  ): S
+}
+
 export function serialize(
   obj: Record<string, unknown>,
   serializer: Serializer = { serialize: JSON.stringify, deserialize: JSON.parse },
 ) {
   return serializer.deserialize(serializer.serialize(obj))
+}
+export function merge<S>(
+  key: string | number | symbol,
+  localState: S,
+  sharedState: S,
+  storeId?: string,
+  merger: Merger = (_, __, shared) => shared,
+): S {
+  return merger(key, localState, sharedState, storeId)
 }


### PR DESCRIPTION
Hi, I’m proposing a merge option (function) to give more control over how local and shared states are combined on updates. 

I initially made it to fix my use case with feathers-pinia where services states get overridden by ones with less data due to how pagination and data is stored nested (when going from a list page to a single item's page for example).

I tried to add it in a similar way as the existing serializer option, it allows to write custom logic for merging states, with access to store IDs and keys for exceptions. 

Let me know if that makes sense, thanks!