### PR TITLE
Fix ignore/lost update by multiple sequential very fast updates (in milliseconds)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export function PiniaSharedState({
         return
 
       externalUpdate = true
-      timestamp = Date.now()
+      timestamp = newState.timestamp
 
       store.$patch((state) => {
         keysToUpdate.forEach((key) => {


### PR DESCRIPTION
Fix for ignore `store.$subscribe` -->`channel.postMessage` message's on tab `channel.onmessage` when changes are very quick after each other.

When 2 changes come to each other fairly quickly (millisecond), the 2nd is sometimes ignored because the `timestamp` is earlier than the `date.now` at which time the previous one came in on the other tab. 
By using the `timestamp` of the incoming store change instead of `date.now`, the 2nd change will not be ignored.