### PR TITLE
Fix timestamp on init request to avoid ignoring the answer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ export function PiniaSharedState({
 
     channel.onmessage = (newState) => {
       if (newState === undefined) {
+        timestamp = Date.now()
         channel.postMessage({
           timestamp,
           state: serialize(store.$state, serializer),

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -56,6 +56,7 @@ export function share<T extends Store, K extends keyof T['$state']>(
 
   channel.onmessage = (evt) => {
     if (evt === undefined) {
+      timestamp = Date.now()
       channel.postMessage({
         timestamp,
         // @ts-expect-error: TODO


### PR DESCRIPTION
Currently, if both sender and receiver start at the same time, their timestamp is 0, because they never serialized anything.

So if a response to an initialize request is sent, it comes with timestamp 0, which is the same.

This patch set a timestamp before each serialization.