### PR TITLE
Use a watcher for the state value instead of $subscribe

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "pinia": "^3.0.0"
   },
   "dependencies": {
-    "broadcast-channel": "^7.0.0"
+    "broadcast-channel": "^7.0.0",
+    "vue": "^3.5.11"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^4.2.0",
@@ -64,7 +65,6 @@
     "eslint": "^9.20.0",
     "pinia": "^3.0.1",
     "tsup": "^8.3.6",
-    "typescript": "^5.3.2",
-    "vue": "^3.5.11"
+    "typescript": "^5.3.2"
   }
 }

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -43,7 +43,7 @@ export function share<T extends Store, K extends keyof T['$state']>(
   let externalUpdate = false
   let timestamp = 0
 
-  store.$subscribe((_, state) => {
+  watch(() => serialize(state, serializer)[key], () => {
     if (!externalUpdate) {
       timestamp = Date.now()
       channel.postMessage({
@@ -66,9 +66,13 @@ export function share<T extends Store, K extends keyof T['$state']>(
     if (evt.timestamp <= timestamp)
       return
 
-    externalUpdate = true
     timestamp = evt.timestamp
-    store[key] = evt.newValue
+    if (store[key] !== evt.newValue) {
+      // Since we are using a watcher, it won't trigger if value are the same,
+      // and externalUpdate won't be reset to false.
+      externalUpdate = true
+      store[key] = evt.newValue
+    }
   }
 
   const sync = () => channel.postMessage(undefined)

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -43,12 +43,12 @@ export function share<T extends Store, K extends keyof T['$state']>(
   let externalUpdate = false
   let timestamp = 0
 
-  watch(() => serialize(state, serializer)[key], () => {
+  watch(() => serialize(store.$state, serializer)[key], newValue => {
     if (!externalUpdate) {
       timestamp = Date.now()
       channel.postMessage({
         timestamp,
-        newValue: serialize(state, serializer)[key],
+        newValue,
       })
     }
     externalUpdate = false


### PR DESCRIPTION
Superseed #52 
Fix #51 

It allows a finer-grained solution, and don't trigger on every store update.

Otherwise, modification of value `a` from store can trigger for share of value `b`.