### PR TITLE
fix: prevent vanilla share collisions across keys

### DIFF
--- a/.changeset/friendly-carpets-smoke.md
+++ b/.changeset/friendly-carpets-smoke.md
@@ -1,0 +1,5 @@
+---
+'pinia-shared-state': patch
+---
+
+Fix vanilla `share()` collisions when multiple keys are shared from the same store. Updates for one key no longer trigger unnecessary broadcasts for other shared keys.

--- a/src/__tests__/vanilla.test.ts
+++ b/src/__tests__/vanilla.test.ts
@@ -257,4 +257,34 @@ describe('share()', () => {
       expect(serialize).toHaveBeenCalled();
     });
   });
+
+  describe('multiple shared keys', () => {
+    it('does not rebroadcast key b when only key a is updated remotely', () => {
+      const id = `multi-${storeCounter}`;
+      const useStore = defineStore(id, () => {
+        const a = ref(false);
+        const b = ref('local');
+        return { a, b };
+      });
+
+      const pinia = createPinia();
+      setActivePinia(pinia);
+      const store = useStore();
+
+      share('a', store, { initialize: false });
+      share('b', store, { initialize: false });
+
+      const channelA = getChannel(`${id}-a`);
+      const channelB = getChannel(`${id}-b`);
+
+      expect(channelA.postedMessages).toHaveLength(0);
+      expect(channelB.postedMessages).toHaveLength(0);
+
+      channelA.onmessage?.({ timestamp: Date.now() + 10_000, newValue: true });
+
+      expect(store.a).toBe(true);
+      expect(store.b).toBe('local');
+      expect(channelB.postedMessages).toHaveLength(0);
+    });
+  });
 });

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -43,12 +43,39 @@ export function share<T extends Store, K extends keyof T['$state']>(
   let externalUpdate = false;
   let timestamp = 0;
 
+  const valueSerializer = serializer ?? {
+    serialize: JSON.stringify,
+    deserialize: JSON.parse,
+  };
+
+  const serializeValue = (value: unknown) => {
+    return valueSerializer.serialize({ value });
+  };
+
+  const deserializeValue = (value: string) => {
+    return valueSerializer.deserialize(value).value;
+  };
+
+  const getStateValue = (state: T['$state']) => {
+    return (state as Record<string, unknown>)[key as string];
+  };
+
+  let lastSerializedValue = serializeValue(getStateValue(store.$state));
+
   store.$subscribe((_, state) => {
+    const nextSerializedValue = serializeValue(getStateValue(state as T['$state']));
+    if (nextSerializedValue === lastSerializedValue) {
+      externalUpdate = false;
+      return;
+    }
+
+    lastSerializedValue = nextSerializedValue;
+
     if (!externalUpdate) {
       timestamp = Date.now();
-      channel.postMessage({
+      void channel.postMessage({
         timestamp,
-        newValue: serialize(state, serializer)[key],
+        newValue: deserializeValue(nextSerializedValue),
       });
     }
     externalUpdate = false;
@@ -56,7 +83,7 @@ export function share<T extends Store, K extends keyof T['$state']>(
 
   channel.onmessage = (evt) => {
     if (evt === undefined) {
-      channel.postMessage({
+      void channel.postMessage({
         timestamp,
         // @ts-expect-error: TODO
         newValue: serialize(store.$state, serializer)[key],
@@ -65,17 +92,26 @@ export function share<T extends Store, K extends keyof T['$state']>(
     }
     if (evt.timestamp <= timestamp) return;
 
-    externalUpdate = true;
+    const incomingSerializedValue = serializeValue(evt.newValue);
+
     timestamp = evt.timestamp;
+    if (incomingSerializedValue === lastSerializedValue) return;
+
+    externalUpdate = true;
+    lastSerializedValue = incomingSerializedValue;
     store.$patch({ [key as string]: evt.newValue } as Partial<typeof store.$state>);
   };
 
-  const sync = () => channel.postMessage(undefined);
+  const sync = () => {
+    void channel.postMessage(undefined);
+  };
   const unshare = () => {
     return channel.close();
   };
 
-  if (initialize) sync();
+  if (initialize) {
+    sync();
+  }
 
   return { sync, unshare };
 }


### PR DESCRIPTION
## Summary
- fix `share()` to track a per-key serialized snapshot so unrelated store key updates do not rebroadcast on other shared keys
- keep existing `$patch` update path and avoid adding new runtime dependencies
- add a regression test that verifies sharing key `a` does not trigger a broadcast for shared key `b`

## Verification
- `vp test run src/__tests__/vanilla.test.ts`
- `vp lint src/vanilla.ts src/__tests__/vanilla.test.ts`

Fixes https://github.com/wobsoriano/pinia-shared-state/issues/51